### PR TITLE
Fix panic when out of gas

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,8 @@ package cryptowatch
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -28,13 +30,14 @@ func (c *CryptwatchClient) Get(resourcePath string, params url.Values) (interfac
 	}
 	defer resp.Body.Close()
 	result := map[string]interface{}{}
-	err = json.NewDecoder(resp.Body).Decode(&result)
-	if err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, err
 	}
-	err = mapstructure.Decode(result["allowance"], &c.Allowance)
-	if err != nil {
+	if err := mapstructure.Decode(result["allowance"], &c.Allowance); err != nil {
 		return nil, err
+	}
+	if err, ok := result["error"].(string); ok {
+		return nil, errors.New(fmt.Sprintf("backend error: '%s'", err))
 	}
 	return result["result"], nil
 }


### PR DESCRIPTION
This fixes a panic when trying to type assert `nil` in the `Price` method here: https://github.com/leonklingele/cryptowatch-go/blob/584ba29617264999553a75bb73958133601bf4bb/client.go#L70

```go
goroutine 8 [running]:
github.com/nakatanakatana/cryptowatch-go.(*CryptwatchClient).Price(/* redacted */)
        /path/to/go/src/github.com/nakatanakatana/cryptowatch-go/client.go:65 +0x14c
[..]
```